### PR TITLE
Add surfaceHub platform to HostClientType (#507)

### DIFF
--- a/src/public/constants.ts
+++ b/src/public/constants.ts
@@ -4,6 +4,7 @@ export enum HostClientType {
   android = 'android',
   ios = 'ios',
   rigel = 'rigel',
+  surfaceHub = 'surfaceHub',
 }
 
 // Ensure these declarations stay in sync with the framework.


### PR DESCRIPTION
* Add surfaceHub2 platform to HostClientType

Add surfaceHub2 platform to HostClientType.
Use this value for SurfaceHub 2s specific scenarios/workflows.

* Update constants.ts

Changing 'surfaceHub2' to generic 'surfaceHub'